### PR TITLE
Add support for the Elastic license

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install:
 lint: deps build
 	@ golint -set_exit_status $(shell go list ./...)
 	@ gofmt -d -e -s $(LINT_FOLDERS)
-	@ ./bin/go-licenser -d
+	@ ./bin/go-licenser -d -exclude golden
 
 .PHONY: format
 format: deps build

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ Usage: go-licenser [flags] [path]
 Options:
 
   -d	skips rewriting files and returns exitcode 1 if any discrepancies are found.
+  -exclude value
+    	path to exclude (can be specified multiple times).
   -ext string
     	sets the file extension to scan for. (default ".go")
+  -license string
+    	sets the license type to check: ASL2, Elastic (default "ASL2")
+
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Options:
     	sets the file extension to scan for. (default ".go")
   -license string
     	sets the license type to check: ASL2, Elastic (default "ASL2")
-
 ```
 
 ## Contributing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,5 +34,5 @@ build_script:
   - go install github.com/elastic/go-licenser
 
 test_script:
-  - go-licenser -d
+  - go-licenser -d -exclude golden
   - go test -timeout 10s -p 4 -race -cover ./...

--- a/fixtures/x-pack/doc.testdata
+++ b/fixtures/x-pack/doc.testdata
@@ -1,0 +1,6 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package testdata holds test data for the licensing cmd
+package testdata

--- a/fixtures/x-pack/wrong.testdata
+++ b/fixtures/x-pack/wrong.testdata
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testdata

--- a/golden/excludedpath/file.go
+++ b/golden/excludedpath/file.go
@@ -1,19 +1,2 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 // Package excludedpath holds test data for the licensing cmd
 package excludedpath

--- a/golden/x-pack/doc.go
+++ b/golden/x-pack/doc.go
@@ -1,0 +1,6 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package testdata holds test data for the licensing cmd
+package testdata

--- a/golden/x-pack/wrong.go
+++ b/golden/x-pack/wrong.go
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testdata

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func init() {
 	flag.Var(&exclude, "exclude", `path to exclude (can be specified multiple times).`)
 	flag.BoolVar(&dryRun, "d", false, `skips rewriting files and returns exitcode 1 if any discrepancies are found.`)
 	flag.StringVar(&extension, "ext", defaultExt, "sets the file extension to scan for.")
-	flag.StringVar(&license, "license", defaultLicense, "sets the license type to check: apache2, elastic")
+	flag.StringVar(&license, "license", defaultLicense, "sets the license type to check: ASL2, Elastic")
 	flag.Usage = usageFlag
 	flag.Parse()
 	args = flag.Args()

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 func run(args []string, license string, exclude []string, ext string, dry bool, out io.Writer) error {
 	header, ok := Headers[license]
 	if !ok {
-		return &Error{err: fmt.Errorf("unkown license: %s", license), code: errUnknownLicense}
+		return &Error{err: fmt.Errorf("unknown license: %s", license), code: errUnknownLicense}
 	}
 
 	var headerBytes []byte

--- a/main_test.go
+++ b/main_test.go
@@ -186,7 +186,7 @@ testdata/x-pack/wrong.go: is missing the license header
 				dry:     false,
 			},
 			want: 7,
-			err:  &Error{err: errors.New("unkown license: foo"), code: 7},
+			err:  &Error{err: errors.New("unknown license: foo"), code: 7},
 		},
 		{
 			name: "Run with default mode rewrites the source files",

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ package main
 import (
 	"bytes"
 	"crypto/sha1"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -106,6 +107,7 @@ func dcopy(src, dest string, info os.FileInfo) error {
 func Test_run(t *testing.T) {
 	type args struct {
 		args    []string
+		license string
 		exclude []string
 		ext     string
 		dry     bool
@@ -122,7 +124,8 @@ func Test_run(t *testing.T) {
 			name: "Run a diff prints a list of files that need the license header",
 			args: args{
 				args:    []string{"testdata"},
-				exclude: []string{"excludedpath"},
+				license: defaultLicense,
+				exclude: []string{"excludedpath", "x-pack"},
 				ext:     defaultExt,
 				dry:     true,
 			},
@@ -140,20 +143,57 @@ testdata/singlelevel/wrapper.go: is missing the license header
 `[1:],
 		},
 		{
+			name: "Run a diff prints a list of files that need the Elastic license header",
+			args: args{
+				args:    []string{"testdata"},
+				license: "Elastic",
+				ext:     defaultExt,
+				dry:     true,
+			},
+			want: 1,
+			err:  &Error{code: 1},
+			wantOutput: `
+testdata/excludedpath/file.go: is missing the license header
+testdata/multilevel/doc.go: is missing the license header
+testdata/multilevel/main.go: is missing the license header
+testdata/multilevel/sublevel/autogen.go: is missing the license header
+testdata/multilevel/sublevel/doc.go: is missing the license header
+testdata/multilevel/sublevel/partial.go: is missing the license header
+testdata/singlelevel/doc.go: is missing the license header
+testdata/singlelevel/main.go: is missing the license header
+testdata/singlelevel/wrapper.go: is missing the license header
+testdata/singlelevel/zrapper.go: is missing the license header
+testdata/x-pack/wrong.go: is missing the license header
+`[1:],
+		},
+		{
 			name: "Run against an unexisting dir fails",
 			args: args{
-				args: []string{"ignore"},
-				ext:  defaultExt,
-				dry:  false,
+				args:    []string{"ignore"},
+				license: defaultLicense,
+				ext:     defaultExt,
+				dry:     false,
 			},
 			want: 2,
 			err:  goosPathError(2, "ignore"),
 		},
 		{
+			name: "Unknown license fails",
+			args: args{
+				args:    []string{"ignore"},
+				license: "foo",
+				ext:     defaultExt,
+				dry:     false,
+			},
+			want: 7,
+			err:  &Error{err: errors.New("unkown license: foo"), code: 7},
+		},
+		{
 			name: "Run with default mode rewrites the source files",
 			args: args{
 				args:    []string{"testdata"},
-				exclude: []string{"excludedpath"},
+				license: defaultLicense,
+				exclude: []string{"excludedpath", "x-pack"},
 				ext:     defaultExt,
 				dry:     false,
 			},
@@ -168,7 +208,7 @@ testdata/singlelevel/wrapper.go: is missing the license header
 			}
 
 			var buf = new(bytes.Buffer)
-			var err = run(tt.args.args, tt.args.exclude, tt.args.ext, tt.args.dry, buf)
+			var err = run(tt.args.args, tt.args.license, tt.args.exclude, tt.args.ext, tt.args.dry, buf)
 			if !reflect.DeepEqual(err, tt.err) {
 				t.Errorf("run() error = %v, wantErr %v", err, tt.err)
 				return
@@ -188,7 +228,7 @@ testdata/singlelevel/wrapper.go: is missing the license header
 			if tt.wantGolden {
 				if *update {
 					copyFixtures(t, "golden")
-					if err := run([]string{"golden"}, tt.args.exclude, tt.args.ext, tt.args.dry, buf); err != nil {
+					if err := run([]string{"golden"}, tt.args.license, tt.args.exclude, tt.args.ext, tt.args.dry, buf); err != nil {
 						t.Fatal(err)
 					}
 				}


### PR DESCRIPTION
## Description
 
Introduces support for multiple licenses through the `--license` flag, keeping the
current one (`ASL2`) as the default, and adding an `Elastic` option.

Closes #1