### PR TITLE
Add -version flag to binary and release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 testdata
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,24 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+builds:
+- env:
+  - CGO_ENABLED=0
+  ldflags: -s -w -X main.version={{.Env.VERSION }} -X main.commit={{.Commit}}
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Env.VERSION }}-SNAPSHOT-{{ .Commit }}"
+dist: dist
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Options:
     	sets the file extension to scan for. (default ".go")
   -license string
     	sets the license type to check: ASL2, Elastic (default "ASL2")
+  -version
+    	prints out the binary version.
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ is useful outside of Elastic **_at the current stage_**, but the `licensing` pac
 ## Supported Licenses
 
 * Apache 2.0
+* Elastic
 
 ## Supported languages
 

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func (f *sliceFlag) Set(value string) error {
 func init() {
 	flag.Var(&exclude, "exclude", `path to exclude (can be specified multiple times).`)
 	flag.BoolVar(&dryRun, "d", false, `skips rewriting files and returns exitcode 1 if any discrepancies are found.`)
-	flag.BoolVar(&showVersion, "version", false, `skips rewriting files and returns exitcode 1 if any discrepancies are found.`)
+	flag.BoolVar(&showVersion, "version", false, `prints out the binary version.`)
 	flag.StringVar(&extension, "ext", defaultExt, "sets the file extension to scan for.")
 	flag.StringVar(&license, "license", defaultLicense, "sets the license type to check: ASL2, Elastic")
 	flag.Usage = usageFlag

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ var Headers = map[string][]string{
 
 var (
 	dryRun             bool
+	showVersion        bool
 	extension          string
 	args               []string
 	license            string
@@ -110,6 +111,7 @@ func (f *sliceFlag) Set(value string) error {
 func init() {
 	flag.Var(&exclude, "exclude", `path to exclude (can be specified multiple times).`)
 	flag.BoolVar(&dryRun, "d", false, `skips rewriting files and returns exitcode 1 if any discrepancies are found.`)
+	flag.BoolVar(&showVersion, "version", false, `skips rewriting files and returns exitcode 1 if any discrepancies are found.`)
 	flag.StringVar(&extension, "ext", defaultExt, "sets the file extension to scan for.")
 	flag.StringVar(&license, "license", defaultLicense, "sets the license type to check: ASL2, Elastic")
 	flag.Usage = usageFlag
@@ -118,6 +120,11 @@ func init() {
 }
 
 func main() {
+	if showVersion {
+		fmt.Printf("go-licenser %s (%s)\n", version, commit)
+		return
+	}
+
 	err := run(args, license, exclude, extension, dryRun, os.Stdout)
 	if err != nil && err.Error() != "<nil>" {
 		fmt.Fprint(os.Stderr, err)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+var (
+	version string
+	commit  string
+)


### PR DESCRIPTION
## Description
This change updates `go-licenser` to have a `-version` flag which prints
out the current binary version. Additionally adds goreleaser to automate
the releasing process. Also bumps the version to `0.2.0`.

## Related issues

Resolves #16 