### PR TITLE
go.mod: Define go-licenser module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/elastic/go-licenser


### PR DESCRIPTION
## Description

As part of the _vgo_ effort, all Go projects need to have a `go.mod` file that define what module they're part of and their dependencies, since `go-licenser` doesn't rely on any external dependencies the definition is quite simple.

## Related issues

* Part of #16