### PR TITLE
Add cloud license to the go-licenser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options:
   -ext string
     	sets the file extension to scan for. (default ".go")
   -license string
-    	sets the license type to check: ASL2, Elastic (default "ASL2")
+    	sets the license type to check: ASL2, Elastic, Cloud (default "ASL2")
   -version
     	prints out the binary version.
 ```

--- a/fixtures/cloud/doc.testdata
+++ b/fixtures/cloud/doc.testdata
@@ -1,0 +1,17 @@
+// ELASTICSEARCH CONFIDENTIAL
+// __________________
+//
+//  Copyright Elasticsearch B.V. All rights reserved.
+//
+// NOTICE:  All information contained herein is, and remains
+// the property of Elasticsearch B.V. and its suppliers, if any.
+// The intellectual and technical concepts contained herein
+// are proprietary to Elasticsearch B.V. and its suppliers and
+// may be covered by U.S. and Foreign Patents, patents in
+// process, and are protected by trade secret or copyright
+// law.  Dissemination of this information or reproduction of
+// this material is strictly forbidden unless prior written
+// permission is obtained from Elasticsearch B.V.
+
+// Package testdata holds test data for the licensing cmd
+package testdata

--- a/fixtures/cloud/wrong.testdata
+++ b/fixtures/cloud/wrong.testdata
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testdata

--- a/golden/cloud/doc.go
+++ b/golden/cloud/doc.go
@@ -1,0 +1,17 @@
+// ELASTICSEARCH CONFIDENTIAL
+// __________________
+//
+//  Copyright Elasticsearch B.V. All rights reserved.
+//
+// NOTICE:  All information contained herein is, and remains
+// the property of Elasticsearch B.V. and its suppliers, if any.
+// The intellectual and technical concepts contained herein
+// are proprietary to Elasticsearch B.V. and its suppliers and
+// may be covered by U.S. and Foreign Patents, patents in
+// process, and are protected by trade secret or copyright
+// law.  Dissemination of this information or reproduction of
+// this material is strictly forbidden unless prior written
+// permission is obtained from Elasticsearch B.V.
+
+// Package testdata holds test data for the licensing cmd
+package testdata

--- a/golden/cloud/wrong.go
+++ b/golden/cloud/wrong.go
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testdata

--- a/main.go
+++ b/main.go
@@ -81,6 +81,22 @@ var Headers = map[string][]string{
 		`// or more contributor license agreements. Licensed under the Elastic License;`,
 		`// you may not use this file except in compliance with the Elastic License.`,
 	},
+	"Cloud": {
+		`// ELASTICSEARCH CONFIDENTIAL`,
+		`// __________________`,
+		`//`,
+		`//  Copyright Elasticsearch B.V. All rights reserved.`,
+		`//`,
+		`// NOTICE:  All information contained herein is, and remains`,
+		`// the property of Elasticsearch B.V. and its suppliers, if any.`,
+		`// The intellectual and technical concepts contained herein`,
+		`// are proprietary to Elasticsearch B.V. and its suppliers and`,
+		`// may be covered by U.S. and Foreign Patents, patents in`,
+		`// process, and are protected by trade secret or copyright`,
+		`// law.  Dissemination of this information or reproduction of`,
+		`// this material is strictly forbidden unless prior written`,
+		`// permission is obtained from Elasticsearch B.V.`,
+	},
 }
 
 var (
@@ -113,7 +129,7 @@ func init() {
 	flag.BoolVar(&dryRun, "d", false, `skips rewriting files and returns exitcode 1 if any discrepancies are found.`)
 	flag.BoolVar(&showVersion, "version", false, `prints out the binary version.`)
 	flag.StringVar(&extension, "ext", defaultExt, "sets the file extension to scan for.")
-	flag.StringVar(&license, "license", defaultLicense, "sets the license type to check: ASL2, Elastic")
+	flag.StringVar(&license, "license", defaultLicense, "sets the license type to check: ASL2, Elastic, Cloud")
 	flag.Usage = usageFlag
 	flag.Parse()
 	args = flag.Args()

--- a/main_test.go
+++ b/main_test.go
@@ -125,7 +125,7 @@ func Test_run(t *testing.T) {
 			args: args{
 				args:    []string{"testdata"},
 				license: defaultLicense,
-				exclude: []string{"excludedpath", "x-pack"},
+				exclude: []string{"excludedpath", "x-pack", "cloud"},
 				ext:     defaultExt,
 				dry:     true,
 			},
@@ -153,6 +153,8 @@ testdata/singlelevel/wrapper.go: is missing the license header
 			want: 1,
 			err:  &Error{code: 1},
 			wantOutput: `
+testdata/cloud/doc.go: is missing the license header
+testdata/cloud/wrong.go: is missing the license header
 testdata/excludedpath/file.go: is missing the license header
 testdata/multilevel/doc.go: is missing the license header
 testdata/multilevel/main.go: is missing the license header
@@ -163,6 +165,32 @@ testdata/singlelevel/doc.go: is missing the license header
 testdata/singlelevel/main.go: is missing the license header
 testdata/singlelevel/wrapper.go: is missing the license header
 testdata/singlelevel/zrapper.go: is missing the license header
+testdata/x-pack/wrong.go: is missing the license header
+`[1:],
+		},
+		{
+			name: "Run a diff prints a list of files that need the Cloud license header",
+			args: args{
+				args:    []string{"testdata"},
+				license: "Cloud",
+				ext:     defaultExt,
+				dry:     true,
+			},
+			want: 1,
+			err:  &Error{code: 1},
+			wantOutput: `
+testdata/cloud/wrong.go: is missing the license header
+testdata/excludedpath/file.go: is missing the license header
+testdata/multilevel/doc.go: is missing the license header
+testdata/multilevel/main.go: is missing the license header
+testdata/multilevel/sublevel/autogen.go: is missing the license header
+testdata/multilevel/sublevel/doc.go: is missing the license header
+testdata/multilevel/sublevel/partial.go: is missing the license header
+testdata/singlelevel/doc.go: is missing the license header
+testdata/singlelevel/main.go: is missing the license header
+testdata/singlelevel/wrapper.go: is missing the license header
+testdata/singlelevel/zrapper.go: is missing the license header
+testdata/x-pack/doc.go: is missing the license header
 testdata/x-pack/wrong.go: is missing the license header
 `[1:],
 		},
@@ -193,7 +221,7 @@ testdata/x-pack/wrong.go: is missing the license header
 			args: args{
 				args:    []string{"testdata"},
 				license: defaultLicense,
-				exclude: []string{"excludedpath", "x-pack"},
+				exclude: []string{"excludedpath", "x-pack", "cloud"},
 				ext:     defaultExt,
 				dry:     false,
 			},


### PR DESCRIPTION
The cloud license used for cloud source code seems to be different
from the beats Elastic license, so I've added it here as a specific
Cloud option.

We intend to use this with the go proxy code.

Signed-off-by: franek <franek@elastic.co>