### PR TITLE
release: Fix goreleaser for v0.3.0 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,17 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+release:
+  github:
+    owner: elastic
+    name: go-licenser
 builds:
 - env:
   - CGO_ENABLED=0
   ldflags: -s -w -X main.version={{.Env.VERSION }} -X main.commit={{.Commit}}
+  goos:
+    - linux
+    - darwin
+    - windows
 archive:
   replacements:
     darwin: Darwin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION := 0.2.0
+export VERSION := v0.3.0
 export GO111MODULE ?= on
 OWNER ?= elastic
 REPO ?= go-licenser


### PR DESCRIPTION
## Description
Fixes the Goreleaser file so the GitHub release is posted to the right
repository and adds Windows as a build architecture.

Additionally it bumps the version to v0.3.0.