### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go get -u github.com/elastic/go-licenser
 ```
 Usage: go-licenser [flags] [path]
 
-  go-licenser walks the specified path recursiely and appends a license Header if the current
+  go-licenser walks the specified path recursively and appends a license Header if the current
   header doesn't match the one found in the file.
 
 Options:

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ const (
 var usageText = `
 Usage: go-licenser [flags] [path]
 
-  go-licenser walks the specified path recursiely and appends a license Header if the current
+  go-licenser walks the specified path recursively and appends a license Header if the current
   header doesn't match the one found in the file.
 
 Options:


### PR DESCRIPTION
Fixes `recursiely -> resursively` in the README and help output.