### PR TITLE
Fix broken file extensions in paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func walk(p, ext, license string, headerBytes []byte, exclude []string, dry bool
 		}
 
 		var currentPath = cleanPathPrefixes(
-			strings.Replace(path, p, "", 1),
+			strings.TrimLeft(path, p),
 			[]string{string(os.PathSeparator)},
 		)
 


### PR DESCRIPTION
Before this change when running go-licenser with the `-exclude` flag
pointing to a file, the exclusion rule would never work. When walking the
directory `currentPath` was always losing the first `.` which
corrupted file extensions.

For example,

```
./go-licenser -exclude "pkg/proto/messages/struct.pb.go" -license
"Elastic" -ext ".go"
```
was always replacing the license header in
`pkg/proto/messages/struct.pb.go` because while walking the
`currentPath` would become `pkg/proto/messages/structpb.go`.

After this change `currentPath` is trimmed from the start only.