### PR TITLE
refactor: replace deprecate ioutil calls

### DIFF
--- a/licensing/license.go
+++ b/licensing/license.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -67,13 +66,13 @@ func RewriteFileWithHeader(path string, header []byte) error {
 		return err
 	}
 
-	origin, err := ioutil.ReadFile(path)
+	origin, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
 	data := RewriteWithHeader(origin, header)
-	return ioutil.WriteFile(path, data, info.Mode())
+	return os.WriteFile(path, data, info.Mode())
 }
 
 // RewriteWithHeader rewrites the src byte buffers header with the new header.

--- a/licensing/license_test.go
+++ b/licensing/license_test.go
@@ -20,7 +20,6 @@ package licensing
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -227,7 +226,7 @@ func somefunc() {}
 }
 
 func CreateFileObtainName(t *testing.T) (string, func()) {
-	f, err := ioutil.TempFile(os.TempDir(), "TestHelperCreateFile")
+	f, err := os.CreateTemp(os.TempDir(), "TestHelperCreateFile")
 	if err != nil {
 		t.Error("failed creating temp file", err)
 	}
@@ -241,7 +240,7 @@ func writeContents(t *testing.T, path string, content []byte) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(path, content, info.Mode()); err != nil {
+	if err := os.WriteFile(path, content, info.Mode()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -388,7 +387,7 @@ package main
 			}
 
 			if tt.want != nil {
-				got, err := ioutil.ReadFile(tt.args.path)
+				got, err := os.ReadFile(tt.args.path)
 				if err != nil {
 					t.Error("failed reading contents of temp file")
 				}

--- a/testhelpers.go
+++ b/testhelpers.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,7 +82,7 @@ func dcopy(src, dest string, info os.FileInfo) error {
 		return err
 	}
 
-	infs, err := ioutil.ReadDir(src)
+	infs, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
ioutil was deprecated in Go 1.16 and it is being reported
as a warning in staticcheck, blocking the update to Go 1.17.