### PR TITLE
lint: fix staticcheck issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,6 +272,6 @@ func stringInSlice(a string, list []string) bool {
 }
 
 func usageFlag() {
-	fmt.Fprintf(os.Stderr, usageText)
+	fmt.Fprint(os.Stderr, usageText)
 	flag.PrintDefaults()
 }

--- a/testhelpers.go
+++ b/testhelpers.go
@@ -130,7 +130,7 @@ func hashDirectories(t *testing.T, src, dest string) {
 
 	t.Log("===========================")
 	var srcSum, dstSum = srcHash.Sum(nil), dstHash.Sum(nil)
-	if bytes.Compare(srcSum, dstSum) != 0 {
+	if !bytes.Equal(srcSum, dstSum) {
 		t.Errorf("Contents of %s are not the same as %s", src, dest)
 		t.Errorf("src folder hash: %x", srcSum)
 		t.Errorf("dst folder hash: %x", dstSum)


### PR DESCRIPTION
Golint is deprecated and no longer maintained. Before replacing
it with staticcheck we should make sure the switch is not going
to create more warnings.
This commit should fix all staticcheck issues reported by the
latest version of the linter.