### PR TITLE
ci: run tests on the latest supported versions of go

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
-    GO111MODULE = 'auto'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -39,7 +38,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.17', '1.16', '1.15', '1.14', '1.13'
+            values '1.19', '1.18', '1.17'
           }
           axis {
             name 'PLATFORM'
@@ -50,7 +49,7 @@ pipeline {
           exclude {
             axis {
               name 'GO_VERSION'
-              values '1.16', '1.15', '1.14', '1.13'
+              values '1.19', '1.18', '1.17'
             }
             axis {
               name 'PLATFORM'


### PR DESCRIPTION
CI was testing on ancient versions. Update the matrix to test
on the two supported versions (1.18 + 1.19) and also add 1.17
to be extra sure due to 1.19 being released recently.
