### PR TITLE
perf: use faster walkdir for file walking

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -209,7 +210,7 @@ func reportFile(out io.Writer, f string) {
 
 func walk(p, ext, license string, headerBytes []byte, exclude []string, dry bool, out io.Writer) error {
 	var err error
-	filepath.Walk(p, func(path string, info os.FileInfo, walkErr error) error {
+	filepath.WalkDir(p, func(path string, info fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			err = &Error{err: walkErr, code: exitFailedToWalkPath}
 			return walkErr
@@ -235,7 +236,7 @@ func walk(p, ext, license string, headerBytes []byte, exclude []string, dry bool
 	return err
 }
 
-func addOrCheckLicense(path, ext, license string, headerBytes []byte, info os.FileInfo, dry bool, out io.Writer) error {
+func addOrCheckLicense(path, ext, license string, headerBytes []byte, info fs.DirEntry, dry bool, out io.Writer) error {
 	if info.IsDir() || filepath.Ext(path) != ext {
 		return nil
 	}


### PR DESCRIPTION
Walk is less efficient than WalkDir, introduced in Go 1.16,
which avoids calling os.Lstat on every visited file or directory.

See https://go.dev/doc/go1.16#path/filepath

Benchmark results:

```
name        old time/op    new time/op    delta
Run/dot-16    1.05ms ± 8%    0.89ms ± 7%  -15.43%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
Run/dot-16     241kB ± 0%     225kB ± 0%   -6.94%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
Run/dot-16     2.49k ± 0%     2.37k ± 0%   -4.62%  (p=0.000 n=10+10)
```