### PR TITLE
perf: do not store the whole file in memory but check while reading

### DIFF
--- a/licensing/license.go
+++ b/licensing/license.go
@@ -37,18 +37,26 @@ var (
 // ContainsHeader reads the first N lines of a file and checks if the header
 // matches the one that is expected
 func ContainsHeader(r io.Reader, headerLines []string) bool {
-	var found []string
 	var scanner = bufio.NewScanner(r)
+	var i int
 
-	for scanner.Scan() {
-		found = append(found, scanner.Text())
+	for i = 0; scanner.Scan(); i++ {
+		line := scanner.Bytes()
+
+		// end of license, break out of the loop
+		if i == len(headerLines) {
+			break
+		}
+
+		// compare line by line without storing the whole file
+		// in memory
+		if !bytes.Equal(line, []byte(headerLines[i])) {
+			return false
+		}
 	}
 
-	if len(found) < len(headerLines) {
-		return false
-	}
-
-	if !reflect.DeepEqual(found[:len(headerLines)], headerLines) {
+	// file is shorter than license
+	if i < len(headerLines) {
 		return false
 	}
 


### PR DESCRIPTION
Rework the ContainsHeader to check the header while reading the file
instead of storing the whole file in memory.
We also compare bytes to avoid string allocation.

Benchmarks results:

```
name        old time/op    new time/op    delta
Run/dot-16    1.02ms ±15%    0.70ms ±10%  -31.21%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
Run/dot-16     241kB ± 0%      95kB ± 0%  -60.74%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
Run/dot-16     2.48k ± 0%     0.84k ± 0%  -66.16%  (p=0.000 n=10+10)
```