### PR TITLE
perf: use a buffer pool to reduce allocations

### DIFF
--- a/licensing/headers.go
+++ b/licensing/headers.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package licensing
+
+// Headers is the map of supported licenses
+var Headers = map[string][]string{
+	"ASL2": {
+		`// Licensed to %s under one or more contributor`,
+		`// license agreements. See the NOTICE file distributed with`,
+		`// this work for additional information regarding copyright`,
+		`// ownership. %s licenses this file to you under`,
+		`// the Apache License, Version 2.0 (the "License"); you may`,
+		`// not use this file except in compliance with the License.`,
+		`// You may obtain a copy of the License at`,
+		`//`,
+		`//     http://www.apache.org/licenses/LICENSE-2.0`,
+		`//`,
+		`// Unless required by applicable law or agreed to in writing,`,
+		`// software distributed under the License is distributed on an`,
+		`// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY`,
+		`// KIND, either express or implied.  See the License for the`,
+		`// specific language governing permissions and limitations`,
+		`// under the License.`,
+	},
+	"ASL2-Short": {
+		`// Licensed to %s under one or more agreements.`,
+		`// %s licenses this file to you under the Apache 2.0 License.`,
+		`// See the LICENSE file in the project root for more information.`,
+	},
+	"Elastic": {
+		`// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one`,
+		`// or more contributor license agreements. Licensed under the Elastic License;`,
+		`// you may not use this file except in compliance with the Elastic License.`,
+	},
+	"Elasticv2": {
+		`// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one`,
+		`// or more contributor license agreements. Licensed under the Elastic License 2.0;`,
+		`// you may not use this file except in compliance with the Elastic License 2.0.`,
+	},
+	"Cloud": {
+		`// ELASTICSEARCH CONFIDENTIAL`,
+		`// __________________`,
+		`//`,
+		`//  Copyright Elasticsearch B.V. All rights reserved.`,
+		`//`,
+		`// NOTICE:  All information contained herein is, and remains`,
+		`// the property of Elasticsearch B.V. and its suppliers, if any.`,
+		`// The intellectual and technical concepts contained herein`,
+		`// are proprietary to Elasticsearch B.V. and its suppliers and`,
+		`// may be covered by U.S. and Foreign Patents, patents in`,
+		`// process, and are protected by trade secret or copyright`,
+		`// law.  Dissemination of this information or reproduction of`,
+		`// this material is strictly forbidden unless prior written`,
+		`// permission is obtained from Elasticsearch B.V.`,
+	},
+}

--- a/licensing/license.go
+++ b/licensing/license.go
@@ -34,10 +34,7 @@ var (
 
 	errHeaderIsTooShort = errors.New("header is too short")
 
-	// Supported licenses size are: 173, 232, 240, 636 and 745.
-	// We use a buffer of 768 to make sure everything fit
-	// without any additional allocation.
-	defaulBufSize = 768
+	defaulBufSize int
 	bufPool       = sync.Pool{
 		New: func() interface{} {
 			buf := make([]byte, defaulBufSize)
@@ -45,6 +42,21 @@ var (
 		},
 	}
 )
+
+func init() {
+	// Iterate over the supported licenses to make sure everything fit
+	// without any additional allocation.
+	for _, v := range Headers {
+		var l int
+		for _, v2 := range v {
+			l += len(v2)
+		}
+
+		if l > defaulBufSize {
+			defaulBufSize = l
+		}
+	}
+}
 
 // ContainsHeader reads the first N lines of a file and checks if the header
 // matches the one that is expected

--- a/main.go
+++ b/main.go
@@ -59,59 +59,6 @@ Options:
 
 `[1:]
 
-// Headers is the map of supported licenses
-var Headers = map[string][]string{
-	"ASL2": {
-		`// Licensed to %s under one or more contributor`,
-		`// license agreements. See the NOTICE file distributed with`,
-		`// this work for additional information regarding copyright`,
-		`// ownership. %s licenses this file to you under`,
-		`// the Apache License, Version 2.0 (the "License"); you may`,
-		`// not use this file except in compliance with the License.`,
-		`// You may obtain a copy of the License at`,
-		`//`,
-		`//     http://www.apache.org/licenses/LICENSE-2.0`,
-		`//`,
-		`// Unless required by applicable law or agreed to in writing,`,
-		`// software distributed under the License is distributed on an`,
-		`// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY`,
-		`// KIND, either express or implied.  See the License for the`,
-		`// specific language governing permissions and limitations`,
-		`// under the License.`,
-	},
-	"ASL2-Short": {
-		`// Licensed to %s under one or more agreements.`,
-		`// %s licenses this file to you under the Apache 2.0 License.`,
-		`// See the LICENSE file in the project root for more information.`,
-	},
-	"Elastic": {
-		`// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one`,
-		`// or more contributor license agreements. Licensed under the Elastic License;`,
-		`// you may not use this file except in compliance with the Elastic License.`,
-	},
-	"Elasticv2": {
-		`// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one`,
-		`// or more contributor license agreements. Licensed under the Elastic License 2.0;`,
-		`// you may not use this file except in compliance with the Elastic License 2.0.`,
-	},
-	"Cloud": {
-		`// ELASTICSEARCH CONFIDENTIAL`,
-		`// __________________`,
-		`//`,
-		`//  Copyright Elasticsearch B.V. All rights reserved.`,
-		`//`,
-		`// NOTICE:  All information contained herein is, and remains`,
-		`// the property of Elasticsearch B.V. and its suppliers, if any.`,
-		`// The intellectual and technical concepts contained herein`,
-		`// are proprietary to Elasticsearch B.V. and its suppliers and`,
-		`// may be covered by U.S. and Foreign Patents, patents in`,
-		`// process, and are protected by trade secret or copyright`,
-		`// law.  Dissemination of this information or reproduction of`,
-		`// this material is strictly forbidden unless prior written`,
-		`// permission is obtained from Elasticsearch B.V.`,
-	},
-}
-
 var (
 	dryRun             bool
 	showVersion        bool
@@ -140,7 +87,7 @@ func (f *sliceFlag) Set(value string) error {
 
 func initFlags() {
 	var licenseTypes []string
-	for k := range Headers {
+	for k := range licensing.Headers {
 		licenseTypes = append(licenseTypes, k)
 	}
 	sort.Strings(licenseTypes)
@@ -173,7 +120,7 @@ func main() {
 }
 
 func run(args []string, license, licensor string, exclude []string, ext string, dry bool, out io.Writer) error {
-	header, ok := Headers[license]
+	header, ok := licensing.Headers[license]
 	if !ok {
 		return &Error{err: fmt.Errorf("unknown license: %s", license), code: errUnknownLicense}
 	}
@@ -247,7 +194,7 @@ func addOrCheckLicense(path, ext, license string, headerBytes []byte, info fs.Di
 	}
 	defer f.Close()
 
-	if licensing.ContainsHeader(f, Headers[license]) {
+	if licensing.ContainsHeader(f, licensing.Headers[license]) {
 		return nil
 	}
 


### PR DESCRIPTION
licenses size is known so we can make a pool to reuse the byte slice.
We only read at most len(license) bytes when checking the file header.

Benchmarks:

```
name        old time/op    new time/op    delta
Run/dot-16     443µs ±11%     431µs ±14%     ~     (p=0.549 n=9+10)

name        old alloc/op   new alloc/op   delta
Run/dot-16    78.0kB ± 0%    32.8kB ± 0%  -58.00%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
Run/dot-16       729 ± 0%       714 ± 0%   -2.06%  (p=0.000 n=10+10)
```