### PR TITLE
feat: add multiline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Options:
         sets the license type to check: ASL2, ASL2-Short, Cloud, Elastic, Elasticv2 (default "ASL2")
   -licensor string
         sets the name of the licensor (default "Elasticsearch B.V.")
+  -multiline
+        uses multiline comments
   -version
         prints out the binary version.
 ```

--- a/licensing/headers.go
+++ b/licensing/headers.go
@@ -69,3 +69,18 @@ var Headers = map[string][]string{
 		`// permission is obtained from Elasticsearch B.V.`,
 	},
 }
+
+// HeadersMultiline is a multiline variant map of Headers
+var HeadersMultiline = func() map[string][]string {
+	headersMultiline := map[string][]string{}
+	for licence, headerLines := range Headers {
+		multiLineHeaderLines := []string{`/*`}
+		for _, headerLine := range headerLines {
+			multiHeaderLine := ` *` + headerLine[2:]
+			multiLineHeaderLines = append(multiLineHeaderLines, multiHeaderLine)
+		}
+		multiLineHeaderLines = append(multiLineHeaderLines, ` */`)
+		headersMultiline[licence] = multiLineHeaderLines
+	}
+	return headersMultiline
+}()

--- a/licensing/license.go
+++ b/licensing/license.go
@@ -56,6 +56,16 @@ func init() {
 			defaulBufSize = l
 		}
 	}
+	for _, v := range HeadersMultiline {
+		var l int
+		for _, v2 := range v {
+			l += len(v2)
+		}
+
+		if l > defaulBufSize {
+			defaulBufSize = l
+		}
+	}
 }
 
 // ContainsHeader reads the first N lines of a file and checks if the header

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ var (
 	license            string
 	licensor           string
 	exclude            sliceFlag
+	multiline          bool
 	defaultExludedDirs = []string{"vendor", ".git"}
 )
 
@@ -101,6 +102,7 @@ func initFlags() {
 	flag.StringVar(&extension, "ext", defaultExt, "sets the file extension to scan for.")
 	flag.StringVar(&license, "license", defaultLicense, fmt.Sprintf("sets the license type to check: %s", strings.Join(licenseTypes, ", ")))
 	flag.StringVar(&licensor, "licensor", defaultLicensor, "sets the name of the licensor")
+	flag.BoolVar(&multiline, "multiline", false, `uses multiline comments`)
 	flag.Usage = usageFlag
 	flag.Parse()
 	args = flag.Args()
@@ -127,10 +129,13 @@ func run(args []string, license, licensor string, exclude []string, ext string, 
 	if !ok {
 		return &Error{err: fmt.Errorf("unknown license: %s", license), code: errUnknownLicense}
 	}
+	if multiline {
+		header = licensing.HeadersMultiline[license]
+	}
 
 	var headerBytes []byte
 	if copyright {
-	        year, _, _ := time.Now().Date()
+		year, _, _ := time.Now().Date()
 		headerBytes = append(headerBytes, []byte(fmt.Sprintf("// Copyright %d %s\n", year, licensor))...)
 	}
 	for i, line := range header {


### PR DESCRIPTION
This should fix https://github.com/elastic/go-licenser/issues/6

A new flag is added `-multiline` which uses multiline variants of the existing headers.